### PR TITLE
Update links and phrasing adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PostHTML is a tool for transforming HTML/XML with JS plugins. PostHTML itself is
 
 All HTML transformations are made by plugins. And these plugins are just small plain JS functions, which receive a HTML node tree, transform it, and return a modified tree.
 
-For more detailed information about PostHTML in general take a look at the [docs][docs].
+For more detailed information about PostHTML in general take a look at the [docs][docs-url]
 
 ## Maintainers
 
@@ -39,7 +39,7 @@ For more detailed information about PostHTML in general take a look at the [docs
 
 ## Contributing
 
-See [PostHTML Guidelines](https://github.com/posthtml/posthtml/tree/master/docs) and [CONTRIBUTING](CONTRIBUTING.md).
+See [PostHTML Guidelines](plugins/guide.md) and [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Contributors
 
@@ -63,3 +63,4 @@ See [PostHTML Guidelines](https://github.com/posthtml/posthtml/tree/master/docs)
 [twitter-url]: https://twitter.com/PostHTML
 [chat]: https://badges.gitter.im/posthtml/posthtml.svg
 [chat-url]: https://gitter.im/posthtml/posthtml?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"
+[docs-url]: https://github.com/posthtml/posthtml/tree/master/docs

--- a/packages.md
+++ b/packages.md
@@ -44,7 +44,7 @@ posthtml().process(html, { parser: pug(options) }).then((result) => result.html)
 
 # [Plugins](http://maltsev.github.io/posthtml-plugins)
 
-In case you want to develop your own plugin, we recommend using [posthtml-plugin-boilerplate][plugin] for getting started.
+In case you want to develop your own plugin, we recommend using [posthtml-plugin-boilerplate][plugin] to get started.
 
 [plugin]: https://github.com/posthtml/posthtml-plugin-boilerplate
 
@@ -89,7 +89,7 @@ In case you want to develop your own plugin, we recommend using [posthtml-plugin
 |[posthtml-custom-elements][elem]|[![npm][elem-badge]][elem-npm]|Use custom elements|
 |[posthtml-web-component][web]|[![npm][web-badge]][web-npm]|Web Component server-side rendering, Component as a Service (CaaS)|
 |[posthtml-spaceless][spaceless]|[![npm][spaceless-badge]][spaceless-npm]|Remove whitespace between HTML tags|
-|[posthtml-cache][cache]|[![npm][cache-badge]][cache-npm]|Add a nanoid to links in you tags|
+|[posthtml-cache][cache]|[![npm][cache-badge]][cache-npm]|Add a nanoid to links in your tags|
 |[posthtml-highlight][highlight]|[![npm][highlight-badge]][highlight-npm]|Syntax highlight code elements|
 |[posthtml-pseudo][pseudo]|[![npm][pseudo-badge]][pseudo-npm]|Add pseudo selector class names to elements|
 |[posthtml-noopener][noopener]|[![npm][noopener-badge]][noopener-npm]|Add rel="noopener noreferrer" to links that open in new tab|
@@ -279,7 +279,7 @@ In case you want to develop your own plugin, we recommend using [posthtml-plugin
 |Name|Status|Description|
 |:---|:-----|:----------|
 |[posthtml-img-autosize][img]|[![npm][img-badge]][img-npm]|Auto setting the width and height of \<img\>|
-|[posthtml-to-svg-tags][svg]|[![npm][svg-badge]][svg-npm]|Convert html tags to svg equals|
+|[posthtml-to-svg-tags][svg]|[![npm][svg-badge]][svg-npm]|Convert html tags to svg equivalents|
 |[posthtml-webp][webp]|[![npm][webp-badge]][webp-npm]|Add WebP support for images|
 |[posthtml-favicons][favicons]|[![npm][favicons-badge]][favicons-npm]|Generate Favicons and add related tags|
 |[posthtml-inline-svg][inline-svg]|[![npm][inline-svg-badge]][inline-svg-npm]|Inline svg icons in HTML|

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,7 +2,7 @@
 
 A PostHTML plugin is a simple function with a single argument.
 
-> Use [posthtml-plugin-boilerplate][plugin-boilerplate] boilerplate for create new plugin.
+> Use [posthtml-plugin-boilerplate][plugin-boilerplate] boilerplate to create a new plugin.
 
 ## Synchronous
 

--- a/plugins/guide.md
+++ b/plugins/guide.md
@@ -1,6 +1,6 @@
 # Plugins - Guide
 
-A PostHTML plugin is a function that receives and, usually, transforms a HTML AST from the PostHTML parser. HTML AST has the PostHTML Tree format. [Read more about PostHTML Tree](https://github.com/posthtml/posthtml/blob/master/docs/tree.md).
+A PostHTML plugin is a function that receives and, usually, transforms a HTML AST from the PostHTML parser. HTML AST has the PostHTML Tree format. [Read more about PostHTML Tree](tree.md).
 
 The rules below are mandatory for all PostHTML plugins.
 
@@ -22,7 +22,7 @@ A CI service like Travis is also recommended for testing code in different envir
 
 ## Use only the public PostHTML API
 
-PostHTML plugins must not rely on undocumented properties or methods, which may be subject to change in any minor release. The public API is described in [API docs](https://github.com/posthtml/posthtml/blob/master/docs/api.md).
+PostHTML plugins must not rely on undocumented properties or methods, which may be subject to change in any minor release. The public API is described in [API docs](api.md).
 
 ## Document in English
 


### PR DESCRIPTION
Updated several links to point to internal pages instead of external pages. Not so for the docs link on the front page. Followed the example in the posthtml/posthtml repo but think it might be nice to have this point to an internal page as well, maybe to plugins/README.md.